### PR TITLE
refactor(3_merge_sort): Refactor merge_sort

### DIFF
--- a/introduction_to_python/recursive_functions/3_merge_sort/solutions/.model_solution/solution.py
+++ b/introduction_to_python/recursive_functions/3_merge_sort/solutions/.model_solution/solution.py
@@ -1,32 +1,36 @@
-def merge_sort(num_list):
-    if len(num_list)>1:                 
-        mid = int(len(num_list)/2)      
-        lefthalf = num_list[:mid]       
-        righthalf = num_list[mid:]     
+def merge_sort(numbers: list) -> list:
+    numbers_length = len(numbers)
 
-        merge_sort(lefthalf)
-        merge_sort(righthalf)
+    if numbers_length < 2:
+        return numbers
 
-        i=0
-        j=0
-        k=0
-        
-        while i < len(lefthalf) and j < len(righthalf):
-            if lefthalf[i] < righthalf[j]:
-                num_list[k]=lefthalf[i]
-                i=i+1
-            else:
-                num_list[k]=righthalf[j]
-                j=j+1
-            k=k+1
+    middle_index = numbers_length // 2
+    left_half = numbers[:middle_index]
+    right_half = numbers[middle_index:]
 
-        while i < len(lefthalf):
-            num_list[k]=lefthalf[i]
-            i=i+1
-            k=k+1
+    return _merge(merge_sort(left_half), merge_sort(right_half))
 
-        while j < len(righthalf):
-            num_list[k]=righthalf[j]
-            j=j+1
-            k=k+1
-        return num_list
+
+def _merge(left: list, right: list) -> list:
+    total_length = len(left) + len(right)
+    merged_list = [None] * total_length
+
+    left_index = right_index = merged_list_index = 0
+
+    while left_index < len(left) and right_index < len(right):
+        if left[left_index] < right[right_index]:
+            merged_list[merged_list_index] = left[left_index]
+            left_index += 1
+        else:
+            merged_list[merged_list_index] = right[right_index]
+            right_index += 1
+
+        merged_list_index += 1
+
+    for list_index, list_ in ((left_index, left), (right_index, right)):
+        while list_index < len(list_):
+            merged_list[merged_list_index] = list_[list_index]
+            list_index += 1
+            merged_list_index += 1
+
+    return merged_list


### PR DESCRIPTION
Refactor `merge_sort` with non-public `_merge` function; add typing and descriptive variable names. This includes a fix for returning a `list` if `len(num_list) < 2`.